### PR TITLE
fix: use deb822 to deprecate apt-key

### DIFF
--- a/roles/dcgm_exporter/handlers/main.yml
+++ b/roles/dcgm_exporter/handlers/main.yml
@@ -2,3 +2,4 @@
 - name: Reload ufw
   ansible.builtin.command: ufw reload
   when: ansible_os_family == "Debian"
+  changed_when: true

--- a/roles/dcgm_exporter/tasks/main.yml
+++ b/roles/dcgm_exporter/tasks/main.yml
@@ -38,6 +38,18 @@
     - ansible_os_family == "Debian"
     - docker_check.rc != 0
   block:
+    - name: 創建 keyrings 目錄
+      file:
+        path: /etc/apt/keyrings
+        state: directory
+        mode: '0755'
+
+    - name: 下載並添加 Docker GPG 金鑰
+      get_url:
+        url: https://download.docker.com/linux/ubuntu/gpg
+        dest: /etc/apt/keyrings/docker.asc
+        mode: '0644'
+
     - name: 添加 Docker 儲存庫
       deb822_repository:
         name: docker
@@ -46,8 +58,12 @@
         suites: ["{{ ansible_distribution_release }}"]
         components: [stable]
         architectures: [amd64]
-        signed_by: https://download.docker.com/linux/ubuntu/gpg
+        signed_by: /etc/apt/keyrings/docker.asc
         state: present
+
+    - name: 更新 apt 快取
+      apt:
+        update_cache: yes
 
     - name: 安裝 Docker 套件
       apt:
@@ -95,14 +111,24 @@
     - ansible_os_family == "Debian"
     - not ctk_stat.stat.exists
   block:
+    - name: 下載並添加 NVIDIA Container Toolkit GPG 金鑰
+      get_url:
+        url: https://nvidia.github.io/libnvidia-container/gpgkey
+        dest: /etc/apt/keyrings/nvidia-container-toolkit.asc
+        mode: '0644'
+
     - name: 添加 NVIDIA Container Toolkit 儲存庫
       deb822_repository:
         name: nvidia-container-toolkit
         types: [deb]
         uris: https://nvidia.github.io/libnvidia-container/stable/deb
         suites: [/]
-        signed_by: https://nvidia.github.io/libnvidia-container/gpgkey
+        signed_by: /etc/apt/keyrings/nvidia-container-toolkit.asc
         state: present
+
+    - name: 更新 apt 快取
+      apt:
+        update_cache: yes
 
     - name: 安裝 NVIDIA Container Toolkit
       apt:

--- a/roles/dcgm_exporter/tasks/main.yml
+++ b/roles/dcgm_exporter/tasks/main.yml
@@ -27,16 +27,16 @@
     state: present
   when: pip_check.rc != 0
 
-- name: 檢查 Docker 是否已安裝
-  command: docker --version
-  register: docker_check
-  failed_when: false
-  changed_when: false
+# - name: 檢查 Docker 是否已安裝
+#   command: docker --version
+#   register: docker_check
+#   failed_when: false
+#   changed_when: false
 
 - name: 安裝 Docker (Debian/Ubuntu)
   when:
     - ansible_os_family == "Debian"
-    - docker_check.rc != 0
+    # - docker_check.rc != 0
   block:
     - name: 創建 keyrings 目錄
       file:
@@ -77,10 +77,10 @@
         name: docker
         executable: pip3
 
-- name: Check if nvidia-ctk binary exists
-  ansible.builtin.stat:
-    path: /usr/bin/nvidia-ctk
-  register: ctk_stat
+# - name: Check if nvidia-ctk binary exists
+#   ansible.builtin.stat:
+#     path: /usr/bin/nvidia-ctk
+#   register: ctk_stat
 
 - name: 移除舊的 NVIDIA GPG 金鑰 (如果存在)
   apt_key:
@@ -109,7 +109,7 @@
 - name: 安裝 NVIDIA Container Toolkit (Debian/Ubuntu)
   when:
     - ansible_os_family == "Debian"
-    - not ctk_stat.stat.exists
+    # - not ctk_stat.stat.exists
   block:
     - name: 下載並添加 NVIDIA Container Toolkit GPG 金鑰
       get_url:

--- a/roles/dcgm_exporter/tasks/main.yml
+++ b/roles/dcgm_exporter/tasks/main.yml
@@ -27,12 +27,6 @@
     state: present
   when: pip_check.rc != 0
 
-# - name: 檢查 Docker 是否已安裝
-#   command: docker --version
-#   register: docker_check
-#   failed_when: false
-#   changed_when: false
-
 - name: 清理舊的 APT 配置 (Debian/Ubuntu)
   when: ansible_os_family == "Debian"
   block:
@@ -57,19 +51,9 @@
         - /etc/apt/sources.list.d/docker.list
       failed_when: false
 
-    - name: 移除可能衝突的 Docker 儲存庫檔案
-      file:
-        path: "{{ item }}"
-        state: absent
-      loop:
-        - /etc/apt/sources.list.d/docker.sources
-        - /etc/apt/sources.list.d/nvidia-container-toolkit.sources
-      failed_when: false
-
 - name: 安裝 Docker (Debian/Ubuntu)
   when:
     - ansible_os_family == "Debian"
-    # - docker_check.rc != 0
   block:
     - name: 添加 Docker 儲存庫
       deb822_repository:
@@ -80,7 +64,6 @@
         components: stable
         architectures: amd64
         signed_by: https://download.docker.com/linux/ubuntu/gpg
-        state: present
 
     - name: 更新 apt 快取
       apt:
@@ -98,24 +81,20 @@
         name: docker
         executable: pip3
 
-# - name: Check if nvidia-ctk binary exists
-#   ansible.builtin.stat:
-#     path: /usr/bin/nvidia-ctk
-#   register: ctk_stat
 
 - name: 安裝 NVIDIA Container Toolkit (Debian/Ubuntu)
   when:
     - ansible_os_family == "Debian"
-    # - not ctk_stat.stat.exists
   block:
     - name: 添加 NVIDIA Container Toolkit 儲存庫
       deb822_repository:
         name: nvidia-container-toolkit
         types: deb
-        uris: https://nvidia.github.io/libnvidia-container/stable/deb
-        suites: '{{ ansible_distribution_release }}'
+        uris: https://nvidia.github.io/libnvidia-container/stable/deb/amd64
+        suites: [/]
+        components: []
+        architectures: [amd64]
         signed_by: https://nvidia.github.io/libnvidia-container/gpgkey
-        state: present
 
     - name: 更新 apt 快取
       apt:

--- a/roles/dcgm_exporter/tasks/main.yml
+++ b/roles/dcgm_exporter/tasks/main.yml
@@ -38,14 +38,15 @@
     - ansible_os_family == "Debian"
     - docker_check.rc != 0
   block:
-    - name: 添加 Docker 儲存庫公鑰
-      apt_key:
-        url: https://download.docker.com/linux/ubuntu/gpg
-        state: present
-
     - name: 添加 Docker 儲存庫
-      apt_repository:
-        repo: deb [arch=amd64] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable
+      deb822_repository:
+        name: docker
+        types: [deb]
+        uris: https://download.docker.com/linux/{{ ansible_distribution | lower }}
+        suites: ["{{ ansible_distribution_release }}"]
+        components: [stable]
+        architectures: [amd64]
+        signed_by: https://download.docker.com/linux/ubuntu/gpg
         state: present
 
     - name: 安裝 Docker 套件
@@ -65,25 +66,43 @@
     path: /usr/bin/nvidia-ctk
   register: ctk_stat
 
+- name: 移除舊的 NVIDIA GPG 金鑰 (如果存在)
+  apt_key:
+    url: https://nvidia.github.io/libnvidia-container/gpgkey
+    state: absent
+  when: ansible_os_family == "Debian"
+  failed_when: false
+
+- name: 移除舊的 Docker GPG 金鑰 (如果存在)
+  apt_key:
+    url: https://download.docker.com/linux/ubuntu/gpg
+    state: absent
+  when: ansible_os_family == "Debian"
+  failed_when: false
+
+- name: 移除舊的儲存庫檔案 (如果存在)
+  file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - /etc/apt/sources.list.d/nvidia-container-toolkit.list
+    - /etc/apt/sources.list.d/docker.list
+  when: ansible_os_family == "Debian"
+  failed_when: false
+
 - name: 安裝 NVIDIA Container Toolkit (Debian/Ubuntu)
   when:
     - ansible_os_family == "Debian"
     - not ctk_stat.stat.exists
   block:
-    - name: 添加 NVIDIA GPU 儲存庫公鑰
-      apt_key:
-        url: https://nvidia.github.io/libnvidia-container/gpgkey
-        state: present
-
     - name: 添加 NVIDIA Container Toolkit 儲存庫
-      get_url:
-        url: https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list
-        dest: /etc/apt/sources.list.d/nvidia-container-toolkit.list
-        mode: '0644'
-
-    - name: 更新 apt 套件索引
-      apt:
-        update_cache: yes
+      deb822_repository:
+        name: nvidia-container-toolkit
+        types: [deb]
+        uris: https://nvidia.github.io/libnvidia-container/stable/deb
+        suites: [/]
+        signed_by: https://nvidia.github.io/libnvidia-container/gpgkey
+        state: present
 
     - name: 安裝 NVIDIA Container Toolkit
       apt:
@@ -94,6 +113,7 @@
 - name: 檢查 Docker 是否已配置 NVIDIA Container Runtime
   command: docker info
   register: docker_runtimes_check
+  changed_when: false
 
 - name: 重新配置 Docker 以支援 NVIDIA Container Runtime
   when:
@@ -101,6 +121,7 @@
   block:
     - name: 配置 Docker
       command: nvidia-ctk runtime configure --runtime=docker
+      changed_when: true
 
     - name: 重新啟動 Docker 服務以套用 NVIDIA Container Runtime 配置
       systemd:
@@ -134,6 +155,7 @@
   command: docker rm -f dcgm-exporter
   when: dcgm_exporter_container.stdout != ""
   failed_when: false
+  changed_when: dcgm_exporter_container.stdout != ""
 
 - name: 運行 DCGM-Exporter Docker 容器
   community.docker.docker_container:

--- a/roles/dcgm_exporter/tasks/main.yml
+++ b/roles/dcgm_exporter/tasks/main.yml
@@ -71,27 +71,15 @@
     - ansible_os_family == "Debian"
     # - docker_check.rc != 0
   block:
-    - name: 創建 keyrings 目錄
-      file:
-        path: /etc/apt/keyrings
-        state: directory
-        mode: '0755'
-
-    - name: 下載並添加 Docker GPG 金鑰
-      get_url:
-        url: https://download.docker.com/linux/ubuntu/gpg
-        dest: /etc/apt/keyrings/docker.asc
-        mode: '0644'
-
     - name: 添加 Docker 儲存庫
       deb822_repository:
         name: docker
         types: [deb]
         uris: https://download.docker.com/linux/{{ ansible_distribution | lower }}
         suites: ["{{ ansible_distribution_release }}"]
-        components: [stable]
-        architectures: [amd64]
-        signed_by: /etc/apt/keyrings/docker.asc
+        components: stable
+        architectures: amd64
+        signed_by: https://download.docker.com/linux/ubuntu/gpg
         state: present
 
     - name: 更新 apt 快取
@@ -120,19 +108,13 @@
     - ansible_os_family == "Debian"
     # - not ctk_stat.stat.exists
   block:
-    - name: 下載並添加 NVIDIA Container Toolkit GPG 金鑰
-      get_url:
-        url: https://nvidia.github.io/libnvidia-container/gpgkey
-        dest: /etc/apt/keyrings/nvidia-container-toolkit.asc
-        mode: '0644'
-
     - name: 添加 NVIDIA Container Toolkit 儲存庫
       deb822_repository:
         name: nvidia-container-toolkit
-        types: [deb]
+        types: deb
         uris: https://nvidia.github.io/libnvidia-container/stable/deb
-        suites: [/]
-        signed_by: /etc/apt/keyrings/nvidia-container-toolkit.asc
+        suites: '{{ ansible_distribution_release }}'
+        signed_by: https://nvidia.github.io/libnvidia-container/gpgkey
         state: present
 
     - name: 更新 apt 快取

--- a/roles/dcgm_exporter/tasks/main.yml
+++ b/roles/dcgm_exporter/tasks/main.yml
@@ -33,6 +33,39 @@
 #   failed_when: false
 #   changed_when: false
 
+- name: 清理舊的 APT 配置 (Debian/Ubuntu)
+  when: ansible_os_family == "Debian"
+  block:
+    - name: 移除舊的 NVIDIA GPG 金鑰 (如果存在)
+      apt_key:
+        url: https://nvidia.github.io/libnvidia-container/gpgkey
+        state: absent
+      failed_when: false
+
+    - name: 移除舊的 Docker GPG 金鑰 (如果存在)
+      apt_key:
+        url: https://download.docker.com/linux/ubuntu/gpg
+        state: absent
+      failed_when: false
+
+    - name: 移除舊的儲存庫檔案 (如果存在)
+      file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - /etc/apt/sources.list.d/nvidia-container-toolkit.list
+        - /etc/apt/sources.list.d/docker.list
+      failed_when: false
+
+    - name: 移除可能衝突的 Docker 儲存庫檔案
+      file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - /etc/apt/sources.list.d/docker.sources
+        - /etc/apt/sources.list.d/nvidia-container-toolkit.sources
+      failed_when: false
+
 - name: 安裝 Docker (Debian/Ubuntu)
   when:
     - ansible_os_family == "Debian"
@@ -81,30 +114,6 @@
 #   ansible.builtin.stat:
 #     path: /usr/bin/nvidia-ctk
 #   register: ctk_stat
-
-- name: 移除舊的 NVIDIA GPG 金鑰 (如果存在)
-  apt_key:
-    url: https://nvidia.github.io/libnvidia-container/gpgkey
-    state: absent
-  when: ansible_os_family == "Debian"
-  failed_when: false
-
-- name: 移除舊的 Docker GPG 金鑰 (如果存在)
-  apt_key:
-    url: https://download.docker.com/linux/ubuntu/gpg
-    state: absent
-  when: ansible_os_family == "Debian"
-  failed_when: false
-
-- name: 移除舊的儲存庫檔案 (如果存在)
-  file:
-    path: "{{ item }}"
-    state: absent
-  loop:
-    - /etc/apt/sources.list.d/nvidia-container-toolkit.list
-    - /etc/apt/sources.list.d/docker.list
-  when: ansible_os_family == "Debian"
-  failed_when: false
 
 - name: 安裝 NVIDIA Container Toolkit (Debian/Ubuntu)
   when:

--- a/roles/monitoring/handlers/main.yml
+++ b/roles/monitoring/handlers/main.yml
@@ -13,3 +13,4 @@
 - name: Reload ufw
   ansible.builtin.command: ufw reload
   when: ansible_os_family == "Debian"
+  changed_when: true

--- a/roles/node_exporter/handlers/main.yml
+++ b/roles/node_exporter/handlers/main.yml
@@ -7,6 +7,7 @@
 - name: Reload ufw
   ansible.builtin.command: ufw reload
   when: ansible_os_family == "Debian"
+  changed_when: true
 
 - name: Reload systemd
   ansible.builtin.systemd:


### PR DESCRIPTION
- **fix: deprecated apt-key**
- **fix: key issue**
- **fix: do not check docker exists so that keyrings can be updated**
- **fix: remove old key before installing**
- **fix: directly use uri**
- **fix: nvidia container toolkit dep repo issue**
